### PR TITLE
Dynamic, just-in-time, creation of node connections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     byebug (6.0.2)
+    cane (3.0.0)
+      parallel
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     diff-lcs (1.2.5)
@@ -61,6 +63,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug (~> 6.0)
+  cane (~> 3.0.0)
   docker-swarm-sdk!
   parallel (~> 1.10)
   pry (~> 0.10.4)
@@ -70,4 +73,4 @@ DEPENDENCIES
   single_cov (~> 0.5.8)
 
 BUNDLED WITH
-   1.14.6
+   1.17.1

--- a/docker-swarm-sdk.gemspec
+++ b/docker-swarm-sdk.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry', '~> 0.10.4'
   gem.add_development_dependency 'single_cov', '~> 0.5.8'
   gem.add_development_dependency 'parallel', '~> 1.10'
+  gem.add_development_dependency 'cane', '~> 3.0.0'
 end

--- a/lib/docker/swarm/node.rb
+++ b/lib/docker/swarm/node.rb
@@ -28,6 +28,12 @@ class Docker::Swarm::Node
   def connection
     if (@swarm) && (@swarm.node_hash[id()])
       return @swarm.node_hash[id()][:connection]
+    elsif self.class.respond_to? :auto_create_connection
+      new_connection = self.class.auto_create_connection( self )
+      if (@swarm) && (@swarm.node_hash[id()])
+        @swarm.node_hash[id()][:connection] = new_connection
+      end
+      return new_connection
     else
       return nil
     end


### PR DESCRIPTION
This allows a developer to define Docker::Swarm::Node#auto_create_connection in which node connections can be created as needed.

```ruby

class Docker::Swarm::Node
  def self.auto_create_connection( node_instance )
    # use node_instance to create and return a connection
  end
end
```

Fixes #10 