### PR TITLE
If node class has an auto_create_connection method, then use that for…

### DIFF
--- a/lib/docker/swarm/node.rb
+++ b/lib/docker/swarm/node.rb
@@ -28,6 +28,12 @@ class Docker::Swarm::Node
   def connection
     if (@swarm) && (@swarm.node_hash[id()])
       return @swarm.node_hash[id()][:connection]
+    elsif self.class.respond_to? :auto_create_connection
+      new_connection = self.class.auto_create_connection( self )
+      if (@swarm) && (@swarm.node_hash[id()])
+        @swarm.node_hash[id()][:connection] = new_connection
+      end
+      return new_connection
     else
       return nil
     end


### PR DESCRIPTION
This allows a developer to define Docker::Swarm::Node#auto_create_connection in which node connections can be created as needed.

```ruby

class Docker::Swarm::Node
  def self.auto_create_connection( node_instance )
    # use node_instance to create and return a connection
  end
end
```

Fixes #10 