### PR TITLE
When creating a new overlay network, only introspect nodes that are ready (Online)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,8 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     byebug (6.0.2)
+    cane (3.0.0)
+      parallel
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     diff-lcs (1.2.5)
@@ -61,6 +63,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug (~> 6.0)
+  cane (~> 3.0.0)
   docker-swarm-sdk!
   parallel (~> 1.10)
   pry (~> 0.10.4)
@@ -70,4 +73,4 @@ DEPENDENCIES
   single_cov (~> 0.5.8)
 
 BUNDLED WITH
-   1.14.6
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -101,3 +101,21 @@ swarm.leave(worker_node, node)
 swarm.leave(manager_node, true)
 
 ```
+
+Development using OSX
+---------------------
+
+Unfortunately, when attempting to run tests on OSX, the following error may occur:
+
+```
+% bundle exec rspec
+    Sorry, you can't use byebug without Readline. To solve this, you need to
+    rebuild Ruby with Readline support. If using Ubuntu, try `sudo apt-get
+    install libreadline-dev` and then reinstall your Ruby.
+```
+
+To work around this, use the following command:
+
+```
+ln -s /usr/local/opt/readline/lib/libreadline.dylib /usr/local/opt/readline/lib/libreadline.7.dylib
+```

--- a/docker-swarm-sdk.gemspec
+++ b/docker-swarm-sdk.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry', '~> 0.10.4'
   gem.add_development_dependency 'single_cov', '~> 0.5.8'
   gem.add_development_dependency 'parallel', '~> 1.10'
+  gem.add_development_dependency 'cane', '~> 3.0.0'
 end

--- a/lib/docker/swarm/node.rb
+++ b/lib/docker/swarm/node.rb
@@ -28,6 +28,12 @@ class Docker::Swarm::Node
   def connection
     if (@swarm) && (@swarm.node_hash[id()])
       return @swarm.node_hash[id()][:connection]
+    elsif self.class.respond_to? :auto_create_connection
+      new_connection = self.class.auto_create_connection( self )
+      if (@swarm) && (@swarm.node_hash[id()])
+        @swarm.node_hash[id()][:connection] = new_connection
+      end
+      return new_connection
     else
       return nil
     end

--- a/lib/docker/swarm/swarm.rb
+++ b/lib/docker/swarm/swarm.rb
@@ -149,7 +149,7 @@ class Docker::Swarm::Swarm
     end
   end
 
-  def create_network_overlay(network_name)
+  def create_network_overlay(network_name,attachable=false)
     subnet_16_parts = [10, 10, 0, 0]
     max_vxlanid = 200
 
@@ -208,6 +208,7 @@ class Docker::Swarm::Swarm
            }
         },
         "Internal" => false,
+        "Attachable" => attachable,
         "Options" => {
           "com.docker.network.driver.overlay.vxlanid_list" => (max_vxlanid + 1).to_s
         },

--- a/lib/docker/swarm/swarm.rb
+++ b/lib/docker/swarm/swarm.rb
@@ -156,6 +156,8 @@ class Docker::Swarm::Swarm
     # Sometimes nodes have leftover networks not on other nodes, that have subnets that can't be duplicated in
     # the new overlay network.
     nodes.each do |node|
+      next unless node.hash['Status']['State'] == 'ready'
+
       node.networks.each do |network|
         if (network.driver == 'overlay')
           if (network.hash['Options'])


### PR DESCRIPTION
Fixes #19 