### PR TITLE
New task features and swarm tasks filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ worker_node.drain()
  # Gather all tasks (containers for service) being hosted by the swarm cluster
 tasks = swarm.tasks()
 
+ # Use filters in query to gather all tasks of a specific service
+ # See https://docs.docker.com/engine/api/v1.40/#operation/TaskList for a list of available filters
+myservice_tasks = swarm.tasks("filters={\"service\":{\"myservice\":true}}")
+
  # Scale up or down the number of replicas on a service
 service.scale(20)
 

--- a/lib/docker/swarm/swarm.rb
+++ b/lib/docker/swarm/swarm.rb
@@ -99,6 +99,9 @@ class Docker::Swarm::Swarm
       items << Swarm::Task.new(self, hash)
     end
     return items
+  # Rescue case where no tasks could be found (API returns 404)
+  rescue Excon::Error::NotFound
+    return []
   end
 
   def leave(node, force = false)

--- a/lib/docker/swarm/swarm.rb
+++ b/lib/docker/swarm/swarm.rb
@@ -90,13 +90,11 @@ class Docker::Swarm::Swarm
     end
   end
 
-  def tasks
+  def tasks(query = {})
     items = []
-    query = {}
     opts = {}
     resp = self.connection.get('/tasks', query, :body => opts.to_json)
     hashes = JSON.parse(resp)
-    items = []
     hashes.each do |hash|
       items << Swarm::Task.new(self, hash)
     end

--- a/lib/docker/swarm/task.rb
+++ b/lib/docker/swarm/task.rb
@@ -38,6 +38,10 @@ class Docker::Swarm::Task
     return DateTime.parse(@hash.first['CreatedAt'])
   end
 
+  def slot
+    @hash['Slot']
+  end
+
   def status
     @hash['Status']['State'].to_sym
   end

--- a/lib/docker/swarm/task.rb
+++ b/lib/docker/swarm/task.rb
@@ -58,6 +58,10 @@ class Docker::Swarm::Task
     @hash['Status']['Message']
   end
 
+  def version_index
+    @hash['Version']['Index']
+  end
+
   def networks
     all_networks = @swarm.networks
     nets = []

--- a/lib/docker/swarm/task.rb
+++ b/lib/docker/swarm/task.rb
@@ -38,6 +38,10 @@ class Docker::Swarm::Task
     return DateTime.parse(@hash.first['CreatedAt'])
   end
 
+  def desired_state
+    @hash['DesiredState']
+  end
+
   def slot
     @hash['Slot']
   end


### PR DESCRIPTION
In this PR I add two new task-related methods in order to get the desired state of a task and to add back the omitted slot method from my previous PR #5 (for some unknown reasons? it was forgotten or omitted). The slot information of a task is indeed very useful.

Furthermore I enable the swarm tasks method to accept a query argument which one can then use to pass filters to the tasks. This change actually resolves issue  #4.

Thank you very much in advance for your consideration and time.